### PR TITLE
First v1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
-# v0.0.3, 2020-04-03
+# Change log
+
+## v1.0.0 (2020-04-06)
+
+- Final tidying and boilerplate updates in `.gemspec` for 'v1' release
+- No functional changes to the gem itself
+
+## v0.0.3 (2020-04-03)
 
 - Revise Ruby compatibility; runs under Ruby 1.9.3-p551 or later (previously only tested under 2.6.5)
 
-# v0.0.2, 2020-04-02
+## v0.0.2 (2020-04-02)
 
 - Fix total-count formatting issue which occurred under certain filter/message conditions
 - Fix copy-paste copyright attribution error in `LICENSE.txt`
 - Maintenance `bundle update`
 
-# v0.0.1, 2020-02-21
+## v0.0.1 (2020-02-21)
 
 - First release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggo (0.0.2)
+    doggo (1.0.0)
       rspec-core (~> 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ gem install doggo
 ...or in a Gemfile:
 
 ```ruby
-gem 'doggo'
+gem 'doggo', '~> 1.0'
 ```
 
 ## Usage
@@ -69,3 +69,13 @@ RSpec.configure do | config |
   config.add_formatter 'Doggo'
 end
 ```
+
+## Development
+
+Doggo works with Ruby 1.9.3-p551 from November 13th 2011, but needs a far newer RubyGems version in order for its `.gemspec` file to be processed. You will therefore probably need to update RubyGems if you are doing development work on the source code and want to, for example, run `bundle update`. _Assuming you are using [rbenv](https://github.com/rbenv/rbenv)_ and have automatically (via Doggo's `.ruby-version` file) or manually (via e.g. running command `rbenv local 1.9.3-p551`) switched to Ruby 1.9.3-p551, you can safely ensure that the most recent compatible RubyGems version is installed by issuing this command:
+
+```
+gem update --system 2.7.10
+```
+
+According to the [release history](https://rubygems.org/gems/rubygems-update/versions), 2.7.10 is the last of the v2.x RubyGems releases which still supported Ruby v1.x. Version 2.7.10 was released on June 14th 2019.

--- a/doggo.gemspec
+++ b/doggo.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ['RIP Global', 'Andrew David Hodgkinson']
   s.email       = ['andrew@ripglobal.com']
   s.license     = 'MIT'
-  s.homepage    = 'http://www.ripglobal.com/'
+  s.homepage    = 'https://www.ripglobal.com/'
 
   s.metadata['homepage_uri'   ] = s.homepage
   s.metadata['source_code_uri'] = 'https://github.com/ripglobal/doggo/'

--- a/doggo.gemspec
+++ b/doggo.gemspec
@@ -2,20 +2,25 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'doggo'
-  s.version     = '0.0.3'
-  s.date        = '2020-04-03'
+  s.version     = '1.0.0'
+  s.date        = '2020-04-06'
   s.summary     = 'RSpec formatter - documentation, with progress indication'
-  s.description = 'Similar to RSpec -f d, but adds indication of test number and total tests on each line'
+  s.description = 'Similar to "rspec -f d", but also indicates progress by showing the current test number and total test count on each line.'
   s.authors     = ['RIP Global', 'Andrew David Hodgkinson']
   s.email       = ['andrew@ripglobal.com']
   s.license     = 'MIT'
+  s.homepage    = 'http://www.ripglobal.com/'
 
-  s.files       = Dir.glob('lib/**/*.rb')
-  s.bindir      = 'bin'
-  s.test_files  = Dir.glob('spec/**/*.rb')
-  s.homepage    = 'https://github.com/ripglobal/doggo/'
+  s.metadata['homepage_uri'   ] = s.homepage
+  s.metadata['source_code_uri'] = 'https://github.com/ripglobal/doggo/'
+  s.metadata['bug_tracker_uri'] = 'https://github.com/ripglobal/doggo/'
+  s.metadata['changelog_uri'  ] = 'https://github.com/ripglobal/doggo/blob/master/CHANGELOG.md'
 
   s.required_ruby_version = '>= 1.9.3'
+  s.bindir                = 'bin'
+  s.files                 = Dir.glob('lib/**/*.rb')
+  s.test_files            = Dir.glob('spec/**/*.rb')
+  s.extra_rdoc_files      = ['LICENSE.txt', 'README.md']
 
   s.add_dependency             'rspec-core','~> 3.0'
   s.add_development_dependency 'rspec',     '~> 3.7'


### PR DESCRIPTION
For `.gemspec` metadata changes, see:

* https://guides.rubygems.org/specification-reference/#metadata