### PR TITLE
Print detailed failure messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## v1.1.0 (2020-04-09)
+
+- Prints detailed failure messages; failing tests can be investigated while the test suite continues to run, rather than waiting for all tests to finish or halting execution at the first failed test
+
 ## v1.0.0 (2020-04-06)
 
 - Final tidying and boilerplate updates in `.gemspec` for 'v1' release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggo (1.0.0)
+    doggo (1.1.0)
       rspec-core (~> 3.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -12,14 +12,56 @@ Regenerate this with `FOR_EXAMPLE=yes bundle exec rspec --order defined`:
 [   10] Doggo examples
 [01/10]   outer passes
 [02/10]   FAILED (1) - outer fails
+
+  1) Doggo examples outer fails
+     Failure/Error: expect(true).to eql(false)
+
+       expected: false
+            got: true
+
+       (compared using eql?)
+
+       Diff:
+       @@ -1,2 +1,2 @@
+       -false
+       +true
+
+     # ./spec/example/doggo_spec.rb:29:in `block (2 levels) in <top (required)>'
+
 [03/10]   PENDING - outer is pending with xit
 [04/10]   FAILED (2) - outer is pending with a custom message
+
+  2) Doggo examples outer is pending with a custom message FIXED
+     Expected pending 'custom message' to fail. No error was raised.
+     # ./spec/example/doggo_spec.rb:35
+
 [   10]   in a context
 [   10]     with a nested context
 [05/10]       passes
 [06/10]       FAILED (3) - fails
+
+  3) Doggo examples in a context with a nested context fails
+     Failure/Error: expect(true).to eql(false)
+
+       expected: false
+            got: true
+
+       (compared using eql?)
+
+       Diff:
+       @@ -1,2 +1,2 @@
+       -false
+       +true
+
+     # ./spec/example/doggo_spec.rb:12:in `block (4 levels) in <top (required)>'
+
 [07/10]       PENDING - is pending with xit
 [08/10]       FAILED (4) - is pending with a custom message
+
+  4) Doggo examples in a context with a nested context is pending with a custom message FIXED
+     Expected pending 'custom message' to fail. No error was raised.
+     # ./spec/example/doggo_spec.rb:18
+
 [   10]   test count
 [09/10]     is taken to 9
 [10/10]     is taken to 10, showing leading zero pad formatting
@@ -31,6 +73,7 @@ Notable things are:
 * Left zero padding to keep column alignment, working for any number of total tests
 * `FAILED` and `PENDING` states are shown on the left side of the message, not the right as with RSpec's `--format documentation`, to make them a little easier to see in CI output
 * A `PENDING` default message of `Temporarily skipped with xit` is suppressed for brevity, but any other message would be shown inline.
+* Detailed failure messages are shown inline, so you can start investigating test failures while your test suite continues to run.
 
 ## Installation
 

--- a/doggo.gemspec
+++ b/doggo.gemspec
@@ -2,9 +2,9 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'doggo'
-  s.version     = '1.0.0'
-  s.date        = '2020-04-06'
-  s.summary     = 'RSpec formatter - documentation, with progress indication'
+  s.version     = '1.1.0'
+  s.date        = '2020-04-09'
+  s.summary     = 'RSpec 3 formatter - documentation, with progress indication'
   s.description = 'Similar to "rspec -f d", but also indicates progress by showing the current test number and total test count on each line.'
   s.authors     = ['RIP Global', 'Andrew David Hodgkinson']
   s.email       = ['andrew@ripglobal.com']
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.metadata['homepage_uri'   ] = s.homepage
   s.metadata['source_code_uri'] = 'https://github.com/ripglobal/doggo/'
-  s.metadata['bug_tracker_uri'] = 'https://github.com/ripglobal/doggo/'
+  s.metadata['bug_tracker_uri'] = 'https://github.com/ripglobal/doggo/issues/'
   s.metadata['changelog_uri'  ] = 'https://github.com/ripglobal/doggo/blob/master/CHANGELOG.md'
 
   s.required_ruby_version = '>= 1.9.3'

--- a/lib/doggo.rb
+++ b/lib/doggo.rb
@@ -71,7 +71,7 @@ class Doggo < RSpec::Core::Formatters::BaseTextFormatter
 
   def example_passed(passed)
     self.outstr.puts(passed_output(passed.example))
-    flush_messages
+    flush_messages()
 
     self.passed_count   += 1
     self.example_running = false
@@ -85,17 +85,21 @@ class Doggo < RSpec::Core::Formatters::BaseTextFormatter
       )
     )
 
-    flush_messages
+    flush_messages()
 
     self.pending_count  += 1
     self.example_running = false
   end
 
   def example_failed(failure)
-    self.outstr.puts(failure_output(failure.example))
-    flush_messages
+    self.failed_count += 1
 
-    self.failed_count   += 1
+    self.outstr.puts(failure_output(failure.example))
+    self.outstr.puts(failure.fully_formatted(self.failed_count))
+    self.outstr.puts("\n")
+
+    flush_messages()
+
     self.example_running = false
   end
 

--- a/spec/internal_spec.rb
+++ b/spec/internal_spec.rb
@@ -91,7 +91,12 @@ RSpec.describe Doggo do
     context '#example_failed' do
       before :each do
         @dog.start(@notification)
+        @detail = 'failure detail'
         @failed = double('Failing test', example: @example)
+
+        allow(@failed).to receive(:fully_formatted) do | count |
+          "#{count} #{@detail}"
+        end
       end
 
       it 'notes an example is no longer running' do
@@ -116,13 +121,20 @@ RSpec.describe Doggo do
         expect(@dog.failed_count).to eql(2)
       end
 
-      it 'logs the failure' do
+      it 'logs the summary failure' do
         @dog.example_started(@notification)
         @dog.example_failed(@failed)
 
         expect(@bork.string).to include("[1/#{@notification.count}]")
         expect(@bork.string).to include('FAILED')
         expect(@bork.string).to include(@example_description)
+      end
+
+      it 'logs the detailed failure' do
+        @dog.example_started(@notification)
+        @dog.example_failed(@failed)
+
+        expect(@bork.string).to include("1 #{@detail}")
       end
     end # "context '#example_failed' do"
 


### PR DESCRIPTION
Prints detailed failure messages; failing tests can be investigated while the test suite continues to run, rather than waiting for all tests to finish or halting execution at the first failed test.

Implementation inspired by https://github.com/grosser/rspec-instafail.